### PR TITLE
update release names

### DIFF
--- a/linux-amd64.Dockerfile
+++ b/linux-amd64.Dockerfile
@@ -21,7 +21,7 @@ ARG PACKAGE_VERSION=${VERSION}
 
 # install app
 RUN mkdir "${APP_DIR}/bin" && \
-    zipfile="/tmp/app.zip" && curl -fsSL -o "${zipfile}" "https://github.com/theotherp/nzbhydra2/releases/download/v${VERSION}/nzbhydra2-${VERSION}-linux.zip" && unzip -q "${zipfile}" -d "${APP_DIR}/bin" && rm "${zipfile}" && \
+    zipfile="/tmp/app.zip" && curl -fsSL -o "${zipfile}" "https://github.com/theotherp/nzbhydra2/releases/download/v${VERSION}/nzbhydra2-${VERSION}-amd64-linux.zip" && unzip -q "${zipfile}" -d "${APP_DIR}/bin" && rm "${zipfile}" && \
     echo "ReleaseType=Release\nPackageVersion=${PACKAGE_VERSION}\nPackageAuthor=hotio" > "${APP_DIR}/package_info" && \
     chmod -R u=rwX,go=rX "${APP_DIR}"
 

--- a/linux-arm64.Dockerfile
+++ b/linux-arm64.Dockerfile
@@ -21,7 +21,7 @@ ARG PACKAGE_VERSION=${VERSION}
 
 # install app
 RUN mkdir "${APP_DIR}/bin" && \
-    zipfile="/tmp/app.zip" && curl -fsSL -o "${zipfile}" "https://github.com/theotherp/nzbhydra2/releases/download/v${VERSION}/nzbhydra2-${VERSION}-linux.zip" && unzip -q "${zipfile}" -d "${APP_DIR}/bin" && rm "${zipfile}" && \
+    zipfile="/tmp/app.zip" && curl -fsSL -o "${zipfile}" "https://github.com/theotherp/nzbhydra2/releases/download/v${VERSION}/nzbhydra2-${VERSION}-arm64-linux.zip" && unzip -q "${zipfile}" -d "${APP_DIR}/bin" && rm "${zipfile}" && \
     echo "ReleaseType=Release\nPackageVersion=${PACKAGE_VERSION}\nPackageAuthor=hotio" > "${APP_DIR}/package_info" && \
     chmod -R u=rwX,go=rX "${APP_DIR}"
 


### PR DESCRIPTION
Since version 5.1.0 the release asset names have changed from:
```
nzbhydra2-5.0.8-linux.zip 
```
to
```
nzbhydra2-5.1.0-amd64-linux.zip
nzbhydra2-5.1.0-arm64-linux.zip
```